### PR TITLE
Added 'showString' to enable use of Arduino IDE

### DIFF
--- a/firmware/src/src.ino
+++ b/firmware/src/src.ino
@@ -149,6 +149,9 @@ const char helpText1[] PROGMEM =                                 // Available Se
 "  s          - save config to EEPROM\n"
 "  v          - Show firmware version\n"
 ;
+
+static void showString(PGM_P s);                                      // Program space string
+
 //################################################################################################################################
 //################################################################################################################################
 #ifndef UNIT_TEST // IMPORTANT LINE! // http://docs.platformio.org/en/stable/plus/unit-testing.html


### PR DESCRIPTION
Using the Arduino IDE (v1.8.13) on Ubuntu (20.10) an error with **'showString’** was not declared in this scope was encountered within **master/firmware/src/src.ino**
The solution is to add:
`static void showString(PGM_P s);`

This is is response to the issue:

- Arduino IDE - 'showString' was not declared in this scope #10