### PR TITLE
Prevent dip switch pullups drawing power if switches closed

### DIFF
--- a/firmware/emonth2.ino
+++ b/firmware/emonth2.ino
@@ -383,6 +383,12 @@ void setup()
   power_timer1_disable();
   // power_timer0_disable();                                           //don't disable necessary for the DS18B20 library
   #endif
+  //turn off pullups on dip switches set to 0V (50k-20k pullup so 66uA-165uA per pin at 3.3V)
+  if (!dip1)
+    pinMode(DIP_switch1, INPUT);
+  if (!dip2)
+    pinMode(DIP_switch2, INPUT);
+
   // Only turn off LED if sensor is working
   if (SI7021_status)
   {


### PR DESCRIPTION
Fixes #24 by turning off dip switch pullups when switches closed. Done when other power saving measures carried out.