### PR TITLE
Handle si7021 returning negative humidity

### DIFF
--- a/firmware/emonth2.ino
+++ b/firmware/emonth2.ino
@@ -318,7 +318,7 @@ void setup()
       si7021_env data = SI7021_sensor.getHumidityAndTemperature();
       Serial.print("SI7021 Started, ID: ");
       Serial.println(deviceid); delay(100);
-      Serial.print("temp:"); Serial.print(data.celsiusHundredths/100.0); Serial.print(",humidity:"); Serial.println(((data.humidityBasisPoints+600)/100.0)-6);
+      Serial.print("temp:"); Serial.print(data.celsiusHundredths/100.0); Serial.print(",humidity:"); Serial.println((int(data.humidityBasisPoints)/100.0));
       delay(100);
     }
     else 
@@ -493,7 +493,7 @@ void loop()
       #endif
       si7021_env data = SI7021_sensor.getHumidityAndTemperature();
       emonth.temp = (data.celsiusHundredths*0.1);
-      emonth.humidity = (((data.humidityBasisPoints+600)*0.1)-60);
+      emonth.humidity = (int(data.humidityBasisPoints)*0.1);
       #ifndef ATTINY
       power_twi_disable();
       #endif

--- a/firmware/emonth2.ino
+++ b/firmware/emonth2.ino
@@ -318,7 +318,7 @@ void setup()
       si7021_env data = SI7021_sensor.getHumidityAndTemperature();
       Serial.print("SI7021 Started, ID: ");
       Serial.println(deviceid); delay(100);
-      Serial.print("temp:"); Serial.print(data.celsiusHundredths/100.0); Serial.print(",humidity:"); Serial.println((int(data.humidityBasisPoints)/100.0));
+      Serial.print("temp:"); Serial.print(data.celsiusHundredths/100.0); Serial.print(",humidity:"); Serial.println(int(data.humidityBasisPoints)/100.0);
       delay(100);
     }
     else 

--- a/firmware/emonth2.ino
+++ b/firmware/emonth2.ino
@@ -318,7 +318,7 @@ void setup()
       si7021_env data = SI7021_sensor.getHumidityAndTemperature();
       Serial.print("SI7021 Started, ID: ");
       Serial.println(deviceid); delay(100);
-      Serial.print("temp:"); Serial.print(data.celsiusHundredths/100.0); Serial.print(",humidity:"); Serial.println(data.humidityBasisPoints/100.0);
+      Serial.print("temp:"); Serial.print(data.celsiusHundredths/100.0); Serial.print(",humidity:"); Serial.println(((data.humidityBasisPoints+600)/100.0)-6);
       delay(100);
     }
     else 
@@ -493,7 +493,7 @@ void loop()
       #endif
       si7021_env data = SI7021_sensor.getHumidityAndTemperature();
       emonth.temp = (data.celsiusHundredths*0.1);
-      emonth.humidity = (data.humidityBasisPoints*0.1);
+      emonth.humidity = (((data.humidityBasisPoints+600)*0.1)-60);
       #ifndef ATTINY
       power_twi_disable();
       #endif


### PR DESCRIPTION
`si7021_env::humidityBasisPoints` is `unsigned int`, but `SI7021::getHumidityBasisPoints` is returning a value ranged from -600 ... 11900 inclusive, where negative values will underflow to 64936 ... 65535.

`struct Payload::humidity` is signed integer and we don't want to modify si7021 library, so we just cast it as signed integer when doing conversion.

Here's one of my emonTH presenting this behavior; my location is constantly very humid so I suspect it has been driven into an extreme state. I'm going to play with built-in heater of si7021 to see if I can make it properly report humidity again.

![firefox_znR4vX1xLV](https://github.com/user-attachments/assets/1f941095-4569-4d34-918e-8a426a0fcc52)
